### PR TITLE
Also handle completion when equal symbol is passed (as in `-arg=...`)

### DIFF
--- a/arg-complete.opam
+++ b/arg-complete.opam
@@ -2,7 +2,7 @@
 opam-version: "2.0"
 synopsis: "Bash completion support for Stdlib.Arg"
 maintainer: ["Simmo Saan <simmo.saan@gmail.com>"]
-authors: ["Simmo Saan <simmo.saan@gmail.com>"]
+authors: ["Simmo Saan <simmo.saan@gmail.com>", "Raphaël Monat <raphael.monat@inria.fr>"]
 license: "MIT"
 homepage: "https://github.com/sim642/ocaml-arg-complete"
 doc: "https://sim642.github.io/ocaml-arg-complete"


### PR DESCRIPTION
This patches the support of arg-complete to handle `-arg=val`, which is supported by `Stdlib.Arg` (and used heavily in Mopsa). 

If the patch works for you, I'd be glad to see a v0.0.2 eventually released on opam :)